### PR TITLE
Added all alternate types that use A20N from default rules

### DIFF
--- a/liveries/Mega Pack/MegaPack_XI_Standard.vmr
+++ b/liveries/Mega Pack/MegaPack_XI_Standard.vmr
@@ -247,4 +247,6268 @@
 	<ModelMatchRule TypeCode="C25C" ModelName="Cessna CJ4 Citation Asobo//Cessna CJ4 Citation Air Ambulance//Cessna CJ4 Citation LifeFlight" />
 	<ModelMatchRule TypeCode="B350" ModelName="Beechcraft King Air 350i Asobo//Beechcraft King Air 350 ADAC//Beechcraft King Air 350 Chrome//Beechcraft King Air 350 Expedition Blue//Beechcraft King Air 350 Expedition Brown//Beechcraft King Air 350 Expedition Burgundy//Beechcraft King Air 350 Expedition Green//Beechcraft King Air 350 Expedition Red//Beechcraft King Air 350 Gunmetal//Beechcraft King Air 350 RNZAF//Beechcraft King Air 350 Royal Flying Doctor Service//Beechcraft King Air 350 Stainless//Beechcraft King Air 350 U.S. Forest Service Fire" />
 	<ModelMatchRule TypeCode="BE36" ModelName="Bonanza G36 Asobo//Bonanza G36 Silver Hornet" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="A318" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="A319" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="A320" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="A321" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="A19N" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="A21N" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B37M" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B38M" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B39M" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B3XM" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B701" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B703" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B712" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B720" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B721" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B722" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B732" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B733" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B734" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B735" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B736" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B737" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B738" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="B379" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="DC91" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="DC92" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="DC93" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="DC94" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="DC95" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="MD81" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="MD82" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="MD83" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="MD87" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="MD88" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="MD90" ModelName="Airbus A320 Neo Cathay Pacific" />
+    <ModelMatchRule CallsignPrefix="CPA" TypeCode="P3" ModelName="Airbus A320 Neo Cathay Pacific" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="A318" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="A319" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="A320" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="A321" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="A19N" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="A21N" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B37M" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B38M" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B39M" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B3XM" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B701" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B703" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B712" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B720" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B721" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B722" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B732" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B733" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B734" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B735" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B736" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B737" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B738" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="B379" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="DC91" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="DC92" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="DC93" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="DC94" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="DC95" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="MD81" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="MD82" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="MD83" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="MD87" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="MD88" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="MD90" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AAL" TypeCode="P3" ModelName="Airbus A320 Neo American" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="A318" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="A319" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="A320" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="A321" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="A19N" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="A21N" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B37M" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B38M" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B39M" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B3XM" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B701" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B703" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B712" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B720" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B721" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B722" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B732" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B733" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B734" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B735" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B736" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B737" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B738" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="B379" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="DC91" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="DC92" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="DC93" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="DC94" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="DC95" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="MD81" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="MD82" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="MD83" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="MD87" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="MD88" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="MD90" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="AEE" TypeCode="P3" ModelName="Airbus A320 Neo Aegean Airlines" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="A318" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="A319" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="A320" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="A321" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="A19N" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="A21N" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B37M" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B38M" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B39M" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B3XM" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B701" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B703" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B712" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B720" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B721" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B722" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B732" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B733" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B734" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B735" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B736" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B737" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B738" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="B379" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="DC91" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="DC92" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="DC93" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="DC94" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="DC95" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="MD81" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="MD82" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="MD83" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="MD87" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="MD88" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="MD90" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="EIN" TypeCode="P3" ModelName="Airbus A320 Neo Aer Lingus//Airbus A320 Neo Aer Lingus Original" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="A318" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="A319" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="A320" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="A321" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="A19N" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="A21N" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B37M" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B38M" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B39M" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B3XM" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B701" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B703" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B712" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B720" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B721" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B722" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B732" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B733" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B734" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B735" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B736" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B737" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B738" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="B379" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="DC91" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="DC92" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="DC93" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="DC94" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="DC95" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="MD81" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="MD82" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="MD83" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="MD87" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="MD88" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="MD90" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="AFL" TypeCode="P3" ModelName="Airbus A320 Neo Aeroflot" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A318" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A319" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A320" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A321" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A19N" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A21N" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B37M" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B38M" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B39M" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B3XM" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B701" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B703" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B712" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B720" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B721" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B722" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B732" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B733" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B734" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B735" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B736" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B737" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B738" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B379" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC91" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC92" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC93" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC94" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC95" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD81" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD82" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD83" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD87" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD88" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD90" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="P3" ModelName="Airbus A320 Neo Aerolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="A318" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="A319" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="A320" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="A321" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="A19N" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="A21N" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B37M" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B38M" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B39M" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B3XM" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B701" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B703" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B712" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B720" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B721" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B722" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B732" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B733" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B734" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B735" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B736" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B737" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B738" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="B379" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="DC91" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="DC92" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="DC93" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="DC94" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="DC95" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="MD81" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="MD82" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="MD83" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="MD87" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="MD88" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="MD90" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="AXM" TypeCode="P3" ModelName="Airbus A320 Neo AirAsia" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="A318" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="A319" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="A320" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="A321" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="A19N" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="A21N" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B37M" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B38M" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B39M" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B701" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B703" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B712" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B720" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B721" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B722" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B732" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B733" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B734" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B735" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B736" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B737" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B738" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="B379" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="DC91" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="DC92" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="DC93" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="DC94" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="DC95" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="MD81" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="MD82" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="MD83" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="MD87" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="MD88" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="MD90" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="FWI" TypeCode="P3" ModelName="Airbus A320 Neo Air Caraibes" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="A318" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="A319" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="A320" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="A321" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="A19N" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="A21N" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B37M" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B38M" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B39M" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B3XM" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B701" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B703" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B712" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B720" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B721" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B722" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B732" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B733" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B734" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B735" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B736" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B737" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B738" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="B379" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="DC91" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="DC92" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="DC93" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="DC94" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="DC95" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="MD81" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="MD82" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="MD83" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="MD87" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="MD88" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="MD90" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AFR" TypeCode="P3" ModelName="Airbus A320 Neo Air France" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="A318" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="A319" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="A320" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="A321" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="A19N" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="A21N" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B37M" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B38M" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B39M" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B3XM" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B701" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B703" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B712" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B720" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B721" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B722" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B732" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B733" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B734" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B735" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B736" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B737" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B738" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="B379" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="DC91" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="DC92" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="DC93" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="DC94" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="DC95" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="MD81" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="MD82" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="MD83" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="MD87" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="MD88" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="MD90" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AIC" TypeCode="P3" ModelName="Airbus A320 Neo Air India" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="A318" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="A319" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="A320" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="A321" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="A19N" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="A21N" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B37M" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B38M" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B39M" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B701" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B703" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B712" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B720" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B721" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B722" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B732" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B733" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B734" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B735" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B736" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B737" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B738" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="B379" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="DC91" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="DC92" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="DC93" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="DC94" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="DC95" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="MD81" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="MD82" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="MD83" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="MD87" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="MD88" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="MD90" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="AEY" TypeCode="P3" ModelName="Airbus A320 Neo Air Italy" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="A318" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="A319" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="A320" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="A321" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="A19N" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="A21N" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B37M" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B38M" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B39M" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B3XM" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B701" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B703" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B712" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B720" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B721" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B722" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B732" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B733" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B734" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B735" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B736" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B737" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B738" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="B379" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="DC91" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="DC92" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="DC93" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="DC94" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="DC95" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="MD81" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="MD82" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="MD83" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="MD87" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="MD88" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="MD90" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="KOR" TypeCode="P3" ModelName="Airbus A320 Neo AirKoryo" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="A318" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="A319" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="A320" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="A321" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="A19N" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="A21N" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B37M" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B38M" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B39M" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B701" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B703" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B712" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B720" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B721" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B722" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B732" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B733" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B734" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B735" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B736" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B737" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B738" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="B379" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="DC91" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="DC92" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="DC93" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="DC94" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="DC95" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="MD81" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="MD82" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="MD83" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="MD87" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="MD88" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="MD90" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="ASL" TypeCode="P3" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="A318" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="A319" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="A320" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="A321" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="A19N" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="A21N" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B37M" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B38M" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B39M" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B701" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B703" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B712" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B720" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B721" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B722" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B732" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B733" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B734" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B735" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B736" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B737" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B738" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="B379" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="DC91" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="DC92" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="DC93" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="DC94" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="DC95" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="MD81" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="MD82" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="MD83" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="MD87" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="MD88" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="MD90" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="JAT" TypeCode="P3" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="A318" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="A319" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="A320" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="A321" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="A19N" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="A21N" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B37M" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B38M" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B39M" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B701" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B703" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B712" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B720" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B721" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B722" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B732" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B733" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B734" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B735" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B736" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B737" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B738" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="B379" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="DC91" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="DC92" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="DC93" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="DC94" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="DC95" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="MD81" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="MD82" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="MD83" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="MD87" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="MD88" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="MD90" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="YRG" TypeCode="P3" ModelName="Airbus A320 Neo Air Serbia" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="A318" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="A319" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="A320" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="A321" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="A19N" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="A21N" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B37M" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B38M" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B39M" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B3XM" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B701" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B703" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B712" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B720" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B721" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B722" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B732" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B733" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B734" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B735" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B736" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B737" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B738" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="B379" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="DC91" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="DC92" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="DC93" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="DC94" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="DC95" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="MD81" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="MD82" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="MD83" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="MD87" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="MD88" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="MD90" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="URR" TypeCode="P3" ModelName="Airbus A320 Neo Aurora Airlines VQ-BBD" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="A318" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="A319" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="A320" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="A321" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="A19N" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="A21N" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B37M" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B38M" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B39M" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B3XM" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B701" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B703" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B712" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B720" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B721" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B722" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B732" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B733" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B734" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B735" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B736" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B737" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B738" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="B379" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="DC91" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="DC92" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="DC93" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="DC94" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="DC95" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="MD81" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="MD82" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="MD83" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="MD87" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="MD88" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="MD90" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="AZA" TypeCode="P3" ModelName="Airbus A320 Neo Alitalia" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A318" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A319" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A320" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A321" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A19N" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A21N" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B37M" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B38M" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B39M" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B3XM" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B701" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B703" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B712" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B720" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B721" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B722" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B732" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B733" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B734" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B735" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B736" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B737" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B738" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B379" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC91" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC92" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC93" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC94" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC95" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD81" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD82" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD83" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD87" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD88" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD90" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="P3" ModelName="Airbus A320 Neo Anadolu Jet" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="A318" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="A319" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="A320" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="A321" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="A19N" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="A21N" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B37M" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B38M" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B39M" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B3XM" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B701" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B703" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B712" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B720" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B721" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B722" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B732" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B733" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B734" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B735" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B736" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B737" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B738" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="B379" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="DC91" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="DC92" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="DC93" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="DC94" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="DC95" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="MD81" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="MD82" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="MD83" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="MD87" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="MD88" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="MD90" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="AAY" TypeCode="P3" ModelName="Airbus A320 Neo ALLEGIANT//Airbus A320 Neo Allegiant Vegas Golden Knights" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="A318" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="A319" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="A320" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="A321" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="A19N" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="A21N" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B37M" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B38M" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B39M" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B3XM" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B701" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B703" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B712" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B720" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B721" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B722" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B732" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B733" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B734" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B735" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B736" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B737" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B738" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="B379" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="DC91" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="DC92" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="DC93" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="DC94" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="DC95" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="MD81" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="MD82" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="MD83" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="MD87" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="MD88" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="MD90" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ANA" TypeCode="P3" ModelName="Airbus A320 Neo ANA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="A318" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="A319" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="A320" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="A321" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="A19N" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="A21N" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B37M" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B38M" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B39M" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B3XM" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B701" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B703" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B712" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B720" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B721" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B722" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B732" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B733" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B734" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B735" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B736" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B737" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B738" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="B379" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="DC91" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="DC92" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="DC93" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="DC94" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="DC95" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="MD81" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="MD82" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="MD83" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="MD87" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="MD88" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="MD90" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ABY" TypeCode="P3" ModelName="Airbus A320 Neo ARABIA" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="A318" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="A319" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="A320" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="A321" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="A19N" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="A21N" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B37M" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B38M" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B39M" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B3XM" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B701" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B703" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B712" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B720" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B721" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B722" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B732" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B733" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B734" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B735" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B736" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B737" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B738" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="B379" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="DC91" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="DC92" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="DC93" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="DC94" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="DC95" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="MD81" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="MD82" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="MD83" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="MD87" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="MD88" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="MD90" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="ASA" TypeCode="P3" ModelName="Airbus A320 Neo Alaska Airlines//Airbus A320 Neo Alaska More To Love" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="A318" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="A319" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="A320" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="A321" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="A19N" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="A21N" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B37M" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B38M" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B39M" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B3XM" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B701" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B703" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B712" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B720" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B721" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B722" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B732" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B733" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B734" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B735" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B736" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B737" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B738" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="B379" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="DC91" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="DC92" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="DC93" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="DC94" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="DC95" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="MD81" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="MD82" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="MD83" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="MD87" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="MD88" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="MD90" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="AAR" TypeCode="P3" ModelName="Airbus A320 Neo Asiana airlines" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="A318" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="A319" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="A320" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="A321" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="A19N" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="A21N" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B37M" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B38M" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B39M" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B3XM" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B701" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B703" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B712" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B720" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B721" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B722" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B732" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B733" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B734" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B735" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B736" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B737" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B738" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="B379" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="DC91" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="DC92" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="DC93" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="DC94" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="DC95" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="MD81" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="MD82" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="MD83" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="MD87" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="MD88" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="MD90" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="ALY" TypeCode="P3" ModelName="Airbus A320 Neo Alas Uruguay" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="A318" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="A319" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="A320" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="A321" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="A19N" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="A21N" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B37M" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B38M" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B39M" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B3XM" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B701" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B703" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B712" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B720" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B721" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B722" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B732" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B733" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B734" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B735" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B736" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B737" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B738" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="B379" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="DC91" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="DC92" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="DC93" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="DC94" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="DC95" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="MD81" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="MD82" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="MD83" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="MD87" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="MD88" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="MD90" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AUA" TypeCode="P3" ModelName="Airbus A320 Neo Austrian//Airbus A320 Neo Austrian New" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="A318" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="A319" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="A320" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="A321" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="A19N" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="A21N" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B37M" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B38M" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B39M" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B3XM" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B701" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B703" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B712" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B720" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B721" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B722" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B732" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B733" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B734" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B735" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B736" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B737" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B738" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="B379" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="DC91" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="DC92" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="DC93" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="DC94" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="DC95" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="MD81" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="MD82" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="MD83" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="MD87" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="MD88" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="MD90" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="AVA" TypeCode="P3" ModelName="Airbus A320 Neo Avianca" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="A318" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="A319" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="A320" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="A321" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="A19N" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="A21N" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B37M" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B38M" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B39M" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B3XM" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B701" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B703" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B712" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B720" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B721" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B722" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B732" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B733" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B734" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B735" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B736" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B737" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B738" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="B379" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="DC91" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="DC92" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="DC93" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="DC94" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="DC95" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="MD81" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="MD82" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="MD83" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="MD87" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="MD88" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="MD90" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="RZO" TypeCode="P3" ModelName="Airbus A320 Neo Azores Wonder//Airbus A320 Neo AZORES AIRLINE NATURAL" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="A318" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="A319" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="A320" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="A321" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="A19N" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="A21N" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B37M" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B38M" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B39M" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B3XM" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B701" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B703" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B712" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B720" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B721" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B722" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B732" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B733" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B734" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B735" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B736" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B737" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B738" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="B379" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="DC91" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="DC92" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="DC93" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="DC94" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="DC95" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="MD81" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="MD82" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="MD83" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="MD87" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="MD88" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="MD90" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="AZU" TypeCode="P3" ModelName="Airbus A320 Neo Azul//Airbus A320 Neo Azul Rosa" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="A318" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="A319" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="A320" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="A321" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="A19N" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="A21N" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B37M" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B38M" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B39M" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B3XM" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B701" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B703" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B712" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B720" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B721" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B722" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B732" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B733" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B734" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B735" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B736" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B737" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B738" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="B379" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="DC91" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="DC92" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="DC93" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="DC94" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="DC95" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="MD81" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="MD82" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="MD83" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="MD87" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="MD88" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="MD90" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BAW" TypeCode="P3" ModelName="Airbus A320 Neo British Airways//Airbus A320 Neo British Airways 2012 Olympic" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="A318" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="A319" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="A320" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="A321" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="A19N" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="A21N" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B37M" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B38M" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B39M" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B3XM" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B701" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B703" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B712" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B720" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B721" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B722" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B732" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B733" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B734" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B735" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B736" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B737" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B738" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="B379" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="DC91" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="DC92" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="DC93" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="DC94" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="DC95" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="MD81" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="MD82" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="MD83" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="MD87" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="MD88" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="MD90" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BTK" TypeCode="P3" ModelName="Airbus A320 Neo Batik" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="A318" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="A319" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="A320" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="A321" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="A19N" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="A21N" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B37M" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B38M" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B39M" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B3XM" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B701" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B703" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B712" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B720" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B721" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B722" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B732" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B733" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B734" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B735" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B736" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B737" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B738" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="B379" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="DC91" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="DC92" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="DC93" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="DC94" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="DC95" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="MD81" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="MD82" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="MD83" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="MD87" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="MD88" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="MD90" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="BRU" TypeCode="P3" ModelName="Airbus A320 Neo Belavia" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="A318" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="A319" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="A320" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="A321" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="A19N" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="A21N" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B37M" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B38M" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B39M" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B3XM" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B701" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B703" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B712" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B720" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B721" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B722" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B732" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B733" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B734" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B735" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B736" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B737" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B738" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="B379" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="DC91" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="DC92" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="DC93" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="DC94" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="DC95" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="MD81" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="MD82" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="MD83" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="MD87" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="MD88" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="MD90" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="RBA" TypeCode="P3" ModelName="Airbus A320 Neo Royal Brunei Airlines" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="A318" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="A319" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="A320" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="A321" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="A19N" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="A21N" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B37M" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B38M" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B39M" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B701" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B703" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B712" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B720" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B721" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B722" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B732" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B733" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B734" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B735" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B736" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B737" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B738" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="B379" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="DC91" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="DC92" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="DC93" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="DC94" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="DC95" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="MD81" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="MD82" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="MD83" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="MD87" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="MD88" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="MD90" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="ACA" TypeCode="P3" ModelName="Airbus A320 Neo Air Canada//Airbus A320 Neo Air Canada Ice Blue//Airbus A320 Neo Air Canada Rouge" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="A318" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="A319" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="A320" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="A321" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="A19N" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="A21N" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B37M" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B38M" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B39M" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B3XM" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B701" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B703" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B712" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B720" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B721" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B722" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B732" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B733" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B734" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B735" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B736" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B737" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B738" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="B379" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="DC91" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="DC92" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="DC93" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="DC94" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="DC95" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="MD81" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="MD82" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="MD83" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="MD87" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="MD88" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="MD90" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="HDA" TypeCode="P3" ModelName="Airbus A320 Neo Cathay Dragon" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="A318" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="A319" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="A320" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="A321" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="A19N" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="A21N" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B37M" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B38M" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B39M" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B3XM" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B701" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B703" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B712" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B720" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B721" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B722" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B732" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B733" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B734" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B735" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B736" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B737" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B738" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="B379" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="DC91" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="DC92" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="DC93" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="DC94" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="DC95" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="MD81" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="MD82" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="MD83" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="MD87" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="MD88" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="MD90" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CDG" TypeCode="P3" ModelName="Airbus A320 Neo Shandong Airlines" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="A318" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="A319" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="A320" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="A321" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="A19N" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="A21N" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B37M" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B38M" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B39M" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B3XM" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B701" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B703" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B712" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B720" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B721" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B722" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B732" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B733" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B734" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B735" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B736" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B737" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B738" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="B379" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="DC91" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="DC92" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="DC93" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="DC94" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="DC95" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="MD81" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="MD82" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="MD83" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="MD87" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="MD88" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="MD90" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CEB" TypeCode="P3" ModelName="Airbus A320 Neo Cebu Pacific" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="A318" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="A319" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="A320" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="A321" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="A19N" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="A21N" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B37M" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B38M" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B39M" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B3XM" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B701" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B703" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B712" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B720" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B721" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B722" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B732" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B733" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B734" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B735" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B736" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B737" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B738" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="B379" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="DC91" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="DC92" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="DC93" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="DC94" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="DC95" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="MD81" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="MD82" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="MD83" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="MD87" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="MD88" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="MD90" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="CCA" TypeCode="P3" ModelName="Airbus A320 Neo Air China" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="A318" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="A319" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="A320" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="A321" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="A19N" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="A21N" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B37M" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B38M" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B39M" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B3XM" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B701" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B703" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B712" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B720" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B721" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B722" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B732" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B733" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B734" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B735" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B736" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B737" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B738" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="B379" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="DC91" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="DC92" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="DC93" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="DC94" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="DC95" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="MD81" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="MD82" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="MD83" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="MD87" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="MD88" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="MD90" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="GIA" TypeCode="P3" ModelName="Airbus A320 Neo Citilink" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="A318" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="A319" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="A320" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="A321" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="A19N" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="A21N" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B37M" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B38M" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B39M" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B3XM" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B701" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B703" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B712" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B720" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B721" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B722" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B732" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B733" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B734" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B735" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B736" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B737" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B738" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="B379" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="DC91" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="DC92" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="DC93" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="DC94" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="DC95" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="MD81" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="MD82" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="MD83" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="MD87" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="MD88" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="MD90" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CAI" TypeCode="P3" ModelName="Airbus A320 Neo Corendon" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="A318" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="A319" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="A320" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="A321" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="A19N" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="A21N" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B37M" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B38M" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B39M" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B3XM" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B701" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B703" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B712" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B720" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B721" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B722" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B732" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B733" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B734" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B735" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B736" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B737" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B738" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="B379" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="DC91" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="DC92" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="DC93" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="DC94" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="DC95" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="MD81" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="MD82" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="MD83" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="MD87" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="MD88" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="MD90" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CQN" TypeCode="P3" ModelName="Airbus A320 Neo Chongqing Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="A318" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="A319" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="A320" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="A321" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="A19N" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="A21N" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B37M" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B38M" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B39M" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B3XM" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B701" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B703" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B712" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B720" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B721" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B722" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B732" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B733" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B734" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B735" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B736" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B737" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B738" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="B379" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="DC91" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="DC92" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="DC93" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="DC94" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="DC95" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="MD81" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="MD82" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="MD83" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="MD87" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="MD88" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="MD90" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSC" TypeCode="P3" ModelName="Airbus A320 Neo Sichuan Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="A318" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="A319" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="A320" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="A321" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="A19N" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="A21N" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B37M" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B38M" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B39M" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B3XM" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B701" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B703" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B712" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B720" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B721" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B722" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B732" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B733" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B734" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B735" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B736" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B737" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B738" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="B379" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="DC91" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="DC92" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="DC93" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="DC94" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="DC95" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="MD81" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="MD82" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="MD83" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="MD87" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="MD88" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="MD90" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CSN" TypeCode="P3" ModelName="Airbus A320 Neo China Southern Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="A318" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="A319" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="A320" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="A321" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="A19N" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="A21N" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B37M" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B38M" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B39M" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B3XM" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B701" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B703" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B712" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B720" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B721" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B722" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B732" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B733" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B734" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B735" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B736" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B737" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B738" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="B379" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="DC91" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="DC92" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="DC93" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="DC94" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="DC95" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="MD81" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="MD82" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="MD83" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="MD87" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="MD88" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="MD90" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="CUA" TypeCode="P3" ModelName="Airbus A320 Neo China United Airlines" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="A318" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="A319" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="A320" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="A321" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="A19N" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="A21N" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B37M" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B38M" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B39M" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B3XM" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B701" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B703" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B712" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B720" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B721" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B722" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B732" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B733" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B734" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B735" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B736" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B737" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B738" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="B379" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="DC91" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="DC92" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="DC93" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="DC94" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="DC95" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="MD81" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="MD82" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="MD83" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="MD87" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="MD88" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="MD90" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAL" TypeCode="P3" ModelName="Airbus A320 Neo Delta" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="A318" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="A319" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="A320" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="A321" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="A19N" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="A21N" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B37M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B38M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B39M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B3XM" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B701" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B703" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B712" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B720" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B721" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B722" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B732" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B733" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B734" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B735" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B736" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B737" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B738" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="B379" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="DC91" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="DC92" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="DC93" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="DC94" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="DC95" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="MD81" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="MD82" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="MD83" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="MD87" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="MD88" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="MD90" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DAE" TypeCode="P3" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="A318" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="A319" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="A320" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="A321" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="A19N" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="A21N" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B37M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B38M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B39M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B3XM" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B701" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B703" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B712" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B720" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B721" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B722" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B732" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B733" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B734" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B735" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B736" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B737" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B738" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="B379" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="DC91" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="DC92" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="DC93" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="DC94" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="DC95" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="MD81" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="MD82" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="MD83" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="MD87" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="MD88" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="MD90" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHX" TypeCode="P3" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="A318" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="A319" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="A320" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="A321" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="A19N" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="A21N" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B37M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B38M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B39M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B3XM" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B701" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B703" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B712" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B720" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B721" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B722" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B732" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B733" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B734" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B735" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B736" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B737" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B738" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="B379" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="DC91" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="DC92" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="DC93" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="DC94" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="DC95" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="MD81" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="MD82" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="MD83" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="MD87" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="MD88" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="MD90" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHV" TypeCode="P3" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="A318" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="A319" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="A320" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="A321" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="A19N" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="A21N" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B37M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B38M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B39M" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B3XM" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B701" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B703" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B712" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B720" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B721" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B722" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B732" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B733" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B734" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B735" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B736" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B737" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B738" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="B379" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="DC91" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="DC92" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="DC93" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="DC94" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="DC95" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="MD81" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="MD82" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="MD83" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="MD87" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="MD88" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="MD90" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="DHK" TypeCode="P3" ModelName="Airbus A320 Neo DHL" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="A318" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="A319" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="A320" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="A321" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="A19N" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="A21N" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B37M" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B38M" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B39M" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B3XM" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B701" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B703" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B712" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B720" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B721" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B722" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B732" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B733" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B734" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B735" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B736" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B737" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B738" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="B379" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="DC91" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="DC92" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="DC93" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="DC94" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="DC95" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="MD81" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="MD82" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="MD83" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="MD87" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="MD88" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="MD90" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="EDW" TypeCode="P3" ModelName="Airbus A320 Neo Edelweiss AI" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="A318" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="A319" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="A320" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="A321" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="A19N" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="A21N" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B37M" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B38M" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B39M" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B3XM" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B701" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B703" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B712" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B720" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B721" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B722" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B732" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B733" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B734" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B735" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B736" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B737" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B738" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="B379" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="DC91" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="DC92" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="DC93" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="DC94" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="DC95" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="MD81" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="MD82" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="MD83" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="MD87" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="MD88" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="MD90" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="MSR" TypeCode="P3" ModelName="Airbus A320 Neo Egypt Air" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="A318" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="A319" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="A320" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="A321" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="A19N" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="A21N" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B37M" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B38M" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B39M" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B3XM" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B701" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B703" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B712" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B720" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B721" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B722" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B732" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B733" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B734" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B735" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B736" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B737" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B738" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="B379" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="DC91" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="DC92" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="DC93" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="DC94" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="DC95" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="MD81" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="MD82" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="MD83" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="MD87" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="MD88" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="MD90" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ELB" TypeCode="P3" ModelName="Airbus A320 Neo ELLINAIR" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="A318" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="A319" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="A320" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="A321" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="A19N" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="A21N" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B37M" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B38M" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B39M" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B3XM" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B701" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B703" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B712" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B720" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B721" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B722" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B732" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B733" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B734" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B735" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B736" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B737" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B738" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="B379" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="DC91" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="DC92" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="DC93" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="DC94" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="DC95" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="MD81" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="MD82" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="MD83" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="MD87" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="MD88" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="MD90" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="ETD" TypeCode="P3" ModelName="Airbus A320 Neo ETIHAD" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="A318" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="A319" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="A320" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="A321" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="A19N" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="A21N" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B37M" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B38M" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B39M" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B3XM" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B701" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B703" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B712" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B720" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B721" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B722" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B732" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B733" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B734" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B735" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B736" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B737" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B738" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="B379" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="DC91" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="DC92" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="DC93" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="DC94" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="DC95" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="MD81" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="MD82" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="MD83" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="MD87" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="MD88" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="MD90" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EVA" TypeCode="P3" ModelName="Airbus A320 Neo Eva Air" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="A318" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="A319" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="A320" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="A321" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="A19N" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="A21N" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B37M" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B38M" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B39M" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B3XM" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B701" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B703" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B712" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B720" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B721" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B722" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B732" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B733" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B734" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B735" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B736" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B737" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B738" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="B379" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="DC91" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="DC92" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="DC93" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="DC94" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="DC95" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="MD81" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="MD82" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="MD83" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="MD87" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="MD88" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="MD90" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWG" TypeCode="P3" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="A318" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="A319" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="A320" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="A321" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="A19N" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="A21N" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B37M" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B38M" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B39M" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B3XM" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B701" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B703" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B712" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B720" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B721" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B722" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B732" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B733" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B734" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B735" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B736" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B737" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B738" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="B379" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="DC91" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="DC92" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="DC93" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="DC94" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="DC95" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="MD81" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="MD82" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="MD83" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="MD87" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="MD88" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="MD90" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EWE" TypeCode="P3" ModelName="Airbus A320 Neo Eurowings" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="A318" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="A319" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="A320" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="A321" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="A19N" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="A21N" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B37M" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B38M" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B39M" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B3XM" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B701" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B703" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B712" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B720" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B721" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B722" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B732" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B733" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B734" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B735" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B736" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B737" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B738" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="B379" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="DC91" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="DC92" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="DC93" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="DC94" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="DC95" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="MD81" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="MD82" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="MD83" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="MD87" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="MD88" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="MD90" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZY" TypeCode="P3" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="A318" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="A319" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="A320" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="A321" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="A19N" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="A21N" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B37M" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B38M" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B39M" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B3XM" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B701" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B703" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B712" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B720" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B721" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B722" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B732" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B733" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B734" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B735" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B736" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B737" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B738" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="B379" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="DC91" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="DC92" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="DC93" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="DC94" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="DC95" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="MD81" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="MD82" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="MD83" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="MD87" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="MD88" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="MD90" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZU" TypeCode="P3" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A318" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A319" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A320" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A321" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A19N" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A21N" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B37M" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B38M" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B39M" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B3XM" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B701" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B703" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B712" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B720" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B721" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B722" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B732" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B733" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B734" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B735" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B736" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B737" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B738" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B379" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC91" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC92" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC93" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC94" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC95" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD81" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD82" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD83" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD87" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD88" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD90" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="P3" ModelName="Airbus A320 Neo EasyJet NEO//Airbus A320 Neo EasyJet" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A318" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A319" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A320" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A321" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A19N" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="A21N" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B37M" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B38M" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B39M" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B3XM" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B701" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B703" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B712" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B720" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B721" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B722" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B732" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B733" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B734" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B735" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B736" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B737" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B738" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="B379" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC91" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC92" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC93" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC94" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="DC95" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD81" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD82" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD83" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD87" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD88" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="MD90" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="EZS" TypeCode="P3" ModelName="Airbus A320 Neo Eva Air//Airbus A320 Neo Eva Air Hello Kitty" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="A318" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="A319" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="A320" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="A321" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="A19N" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="A21N" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B37M" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B38M" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B39M" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B3XM" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B701" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B703" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B712" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B720" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B721" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B722" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B732" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B733" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B734" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B735" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B736" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B737" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B738" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="B379" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="DC91" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="DC92" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="DC93" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="DC94" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="DC95" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="MD81" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="MD82" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="MD83" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="MD87" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="MD88" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="MD90" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FDX" TypeCode="P3" ModelName="Airbus A320 Neo Federal Express" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="A318" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="A319" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="A320" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="A321" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="A19N" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="A21N" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B37M" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B38M" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B39M" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B3XM" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B701" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B703" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B712" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B720" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B721" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B722" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B732" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B733" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B734" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B735" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B736" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B737" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B738" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="B379" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="DC91" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="DC92" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="DC93" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="DC94" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="DC95" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="MD81" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="MD82" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="MD83" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="MD87" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="MD88" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="MD90" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="FIN" TypeCode="P3" ModelName="Airbus A320 Neo Finnair" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="A318" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="A319" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="A320" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="A321" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="A19N" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="A21N" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B37M" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B38M" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B39M" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B3XM" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B701" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B703" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B712" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B720" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B721" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B722" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B732" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B733" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B734" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B735" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B736" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B737" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B738" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="B379" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="DC91" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="DC92" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="DC93" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="DC94" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="DC95" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="MD81" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="MD82" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="MD83" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="MD87" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="MD88" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="MD90" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="BEE" TypeCode="P3" ModelName="Airbus A320 Neo FLYBE" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="A318" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="A319" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="A320" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="A321" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="A19N" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="A21N" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B37M" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B38M" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B39M" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B3XM" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B701" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B703" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B712" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B720" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B721" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B722" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B732" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B733" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B734" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B735" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B736" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B737" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B738" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="B379" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="DC91" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="DC92" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="DC93" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="DC94" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="DC95" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="MD81" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="MD82" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="MD83" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="MD87" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="MD88" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="MD90" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="KNE" TypeCode="P3" ModelName="Airbus A320 Neo Flynas" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="A318" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="A319" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="A320" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="A321" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="A19N" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="A21N" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B37M" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B38M" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B39M" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B3XM" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B701" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B703" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B712" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B720" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B721" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B722" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B732" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B733" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B734" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B735" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B736" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B737" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B738" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="B379" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="DC91" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="DC92" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="DC93" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="DC94" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="DC95" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="MD81" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="MD82" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="MD83" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="MD87" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="MD88" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="MD90" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="FFT" TypeCode="P3" ModelName="Airbus A320 Neo Frontier-AUSTIN//Airbus A320 Neo Frontier-BEAR//Airbus A320 Neo Frontier-BEAVER//Airbus A320 Neo Frontier-BISON//Airbus A320 Neo Frontier-BRONCO//Airbus A320 Neo Frontier-CAT//Airbus A320 Neo Frontier-CHOCO//Airbus A320 Neo Frontier-CLOVER//Airbus A320 Neo Frontier-COATI//Airbus A320 Neo Frontier-CRANE//Airbus A320 Neo Frontier-DOLPHIN//Airbus A320 Neo Frontier-DUCK//Airbus A320 Neo Frontier-FERRET//Airbus A320 Neo Frontier-FLO//Airbus A320 Neo Frontier-FLOWER//Airbus A320 Neo Frontier-FRAN//Airbus A320 Neo Frontier-JOEY//Airbus A320 Neo Frontier-LONESTAR//Airbus A320 Neo Frontier-LYNX//Airbus A320 Neo Frontier-PENGUINS//Airbus A320 Neo Frontier-PIKA//Airbus A320 Neo Frontier-POLAR//Airbus A320 Neo Frontier-SCARLET//Airbus A320 Neo Frontier-SCOUT//Airbus A320 Neo Frontier-SEAGLE//Airbus A320 Neo Frontier-SEAL//Airbus A320 Neo Frontier-SHEEP//Airbus A320 Neo Frontier-SKYE//Airbus A320 Neo Frontier-SWAN//Airbus A320 Neo Frontier-Shelly//Airbus A320 Neo Frontier-TEX//Airbus A320 Neo Frontier-WOOD//Airbus A320 Neo Frontier-WSHARK" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="A318" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="A319" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="A320" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="A321" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="A19N" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="A21N" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B37M" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B38M" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B39M" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B3XM" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B701" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B703" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B712" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B720" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B721" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B722" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B732" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B733" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B734" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B735" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B736" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B737" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B738" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="B379" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="DC91" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="DC92" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="DC93" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="DC94" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="DC95" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="MD81" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="MD82" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="MD83" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="MD87" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="MD88" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="MD90" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GAF" TypeCode="P3" ModelName="Airbus A320 Neo German Air Force" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="A318" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="A319" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="A320" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="A321" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="A19N" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="A21N" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B37M" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B38M" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B39M" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B3XM" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B701" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B703" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B712" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B720" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B721" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B722" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B732" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B733" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B734" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B735" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B736" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B737" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B738" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="B379" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="DC91" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="DC92" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="DC93" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="DC94" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="DC95" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="MD81" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="MD82" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="MD83" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="MD87" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="MD88" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="MD90" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GMI" TypeCode="P3" ModelName="Airbus A320 Neo Germania" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="A318" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="A319" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="A320" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="A321" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="A19N" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="A21N" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B37M" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B38M" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B39M" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B3XM" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B701" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B703" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B712" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B720" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B721" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B722" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B732" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B733" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B734" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B735" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B736" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B737" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B738" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="B379" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="DC91" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="DC92" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="DC93" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="DC94" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="DC95" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="MD81" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="MD82" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="MD83" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="MD87" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="MD88" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="MD90" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GFA" TypeCode="P3" ModelName="Airbus A320 Neo Gulf Air" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="A318" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="A319" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="A320" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="A321" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="A19N" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="A21N" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B37M" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B38M" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B39M" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B3XM" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B701" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B703" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B712" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B720" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B721" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B722" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B732" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B733" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B734" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B735" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B736" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B737" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B738" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="B379" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="DC91" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="DC92" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="DC93" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="DC94" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="DC95" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="MD81" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="MD82" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="MD83" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="MD87" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="MD88" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="MD90" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="GOW" TypeCode="P3" ModelName="Airbus A320 Neo GoAir" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="A318" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="A319" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="A320" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="A321" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="A19N" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="A21N" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B37M" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B38M" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B39M" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B3XM" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B701" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B703" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B712" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B720" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B721" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B722" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B732" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B733" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B734" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B735" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B736" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B737" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B738" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="B379" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="DC91" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="DC92" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="DC93" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="DC94" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="DC95" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="MD81" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="MD82" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="MD83" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="MD87" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="MD88" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="MD90" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="HKE" TypeCode="P3" ModelName="Airbus A320 Neo Hong Kong Express" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="A318" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="A319" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="A320" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="A321" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="A19N" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="A21N" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B37M" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B38M" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B39M" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B3XM" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B701" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B703" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B712" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B720" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B721" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B722" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B732" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B733" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B734" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B735" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B736" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B737" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B738" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="B379" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="DC91" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="DC92" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="DC93" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="DC94" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="DC95" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="MD81" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="MD82" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="MD83" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="MD87" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="MD88" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="MD90" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBE" TypeCode="P3" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="A318" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="A319" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="A320" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="A321" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="A19N" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="A21N" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B37M" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B38M" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B39M" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B3XM" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B701" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B703" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B712" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B720" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B721" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B722" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B732" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B733" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B734" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B735" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B736" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B737" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B738" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="B379" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="DC91" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="DC92" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="DC93" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="DC94" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="DC95" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="MD81" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="MD82" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="MD83" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="MD87" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="MD88" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="MD90" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="IBS" TypeCode="P3" ModelName="Airbus A320 Neo Iberia" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="A318" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="A319" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="A320" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="A321" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="A19N" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="A21N" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B37M" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B38M" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B39M" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B3XM" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B701" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B703" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B712" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B720" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B721" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B722" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B732" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B733" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B734" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B735" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B736" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B737" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B738" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="B379" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="DC91" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="DC92" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="DC93" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="DC94" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="DC95" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="MD81" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="MD82" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="MD83" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="MD87" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="MD88" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="MD90" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="ICE" TypeCode="P3" ModelName="Airbus A320 Neo Iceland Air" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="A318" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="A319" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="A320" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="A321" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="A19N" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="A21N" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B37M" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B38M" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B39M" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B3XM" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B701" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B703" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B712" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B720" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B721" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B722" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B732" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B733" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B734" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B735" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B736" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B737" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B738" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="B379" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="DC91" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="DC92" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="DC93" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="DC94" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="DC95" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="MD81" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="MD82" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="MD83" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="MD87" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="MD88" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="MD90" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IGU" TypeCode="P3" ModelName="Airbus A320 Neo Indigo" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="A318" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="A319" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="A320" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="A321" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="A19N" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="A21N" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B37M" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B38M" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B39M" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B3XM" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B701" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B703" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B712" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B720" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B721" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B722" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B732" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B733" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B734" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B735" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B736" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B737" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B738" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="B379" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="DC91" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="DC92" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="DC93" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="DC94" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="DC95" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="MD81" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="MD82" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="MD83" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="MD87" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="MD88" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="MD90" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IRA" TypeCode="P3" ModelName="Airbus A320 Neo IranAir" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="A318" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="A319" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="A320" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="A321" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="A19N" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="A21N" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B37M" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B38M" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B39M" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B3XM" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B701" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B703" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B712" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B720" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B721" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B722" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B732" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B733" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B734" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B735" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B736" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B737" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B738" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="B379" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="DC91" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="DC92" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="DC93" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="DC94" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="DC95" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="MD81" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="MD82" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="MD83" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="MD87" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="MD88" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="MD90" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="IAW" TypeCode="P3" ModelName="Airbus A320 Neo Iraqi Airways" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="A318" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="A319" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="A320" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="A321" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="A19N" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="A21N" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B37M" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B38M" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B39M" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B3XM" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B701" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B703" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B712" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B720" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B721" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B722" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B732" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B733" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B734" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B735" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B736" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B737" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B738" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="B379" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="DC91" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="DC92" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="DC93" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="DC94" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="DC95" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="MD81" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="MD82" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="MD83" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="MD87" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="MD88" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="MD90" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="ELY" TypeCode="P3" ModelName="Airbus A320 Neo Israel Airlines" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="A318" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="A319" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="A320" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="A321" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="A19N" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="A21N" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B37M" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B38M" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B39M" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B3XM" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B701" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B703" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B712" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B720" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B721" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B722" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B732" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B733" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B734" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B735" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B736" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B737" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B738" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="B379" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="DC91" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="DC92" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="DC93" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="DC94" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="DC95" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="MD81" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="MD82" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="MD83" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="MD87" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="MD88" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="MD90" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="WWW" TypeCode="P3" ModelName="Airbus A320 Neo JANET" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="A318" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="A319" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="A320" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="A321" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="A19N" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="A21N" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B37M" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B38M" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B39M" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B3XM" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B701" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B703" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B712" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B720" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B721" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B722" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B732" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B733" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B734" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B735" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B736" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B737" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B738" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="B379" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="DC91" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="DC92" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="DC93" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="DC94" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="DC95" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="MD81" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="MD82" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="MD83" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="MD87" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="MD88" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="MD90" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JAL" TypeCode="P3" ModelName="Airbus A320 Neo Japan Airlines" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="A318" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="A319" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="A320" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="A321" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="A19N" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="A21N" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B37M" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B38M" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B39M" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B3XM" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B701" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B703" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B712" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B720" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B721" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B722" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B732" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B733" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B734" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B735" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B736" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B737" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B738" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="B379" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="DC91" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="DC92" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="DC93" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="DC94" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="DC95" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="MD81" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="MD82" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="MD83" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="MD87" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="MD88" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="MD90" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="JZR" TypeCode="P3" ModelName="Airbus A320 Neo Jazeera" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="A318" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="A319" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="A320" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="A321" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="A19N" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="A21N" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B37M" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B38M" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B39M" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B3XM" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B701" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B703" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B712" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B720" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B721" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B722" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B732" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B733" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B734" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B735" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B736" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B737" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B738" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="B379" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="DC91" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="DC92" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="DC93" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="DC94" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="DC95" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="MD81" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="MD82" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="MD83" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="MD87" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="MD88" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="MD90" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="EXS" TypeCode="P3" ModelName="Airbus A320 Neo Jet2 AI" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="A318" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="A319" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="A320" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="A321" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="A19N" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="A21N" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B37M" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B38M" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B39M" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B3XM" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B701" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B703" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B712" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B720" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B721" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B722" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B732" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B733" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B734" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B735" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B736" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B737" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B738" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="B379" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="DC91" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="DC92" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="DC93" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="DC94" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="DC95" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="MD81" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="MD82" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="MD83" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="MD87" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="MD88" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="MD90" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JBU" TypeCode="P3" ModelName="Airbus A320 Neo Jetblue Airways" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="A318" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="A319" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="A320" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="A321" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="A19N" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="A21N" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B37M" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B38M" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B39M" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B3XM" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B701" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B703" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B712" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B720" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B721" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B722" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B732" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B733" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B734" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B735" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B736" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B737" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B738" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="B379" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="DC91" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="DC92" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="DC93" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="DC94" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="DC95" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="MD81" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="MD82" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="MD83" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="MD87" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="MD88" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="MD90" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="JST" TypeCode="P3" ModelName="Airbus A320 Neo Jetstar//Airbus A320 Neo Jetstar V2" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="A318" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="A319" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="A320" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="A321" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="A19N" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="A21N" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B37M" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B38M" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B39M" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B3XM" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B701" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B703" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B712" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B720" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B721" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B722" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B732" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B733" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B734" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B735" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B736" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B737" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B738" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="B379" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="DC91" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="DC92" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="DC93" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="DC94" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="DC95" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="MD81" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="MD82" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="MD83" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="MD87" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="MD88" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="MD90" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="KAC" TypeCode="P3" ModelName="Airbus A320 Neo Kuwait Airways" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="A318" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="A319" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="A320" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="A321" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="A19N" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="A21N" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B37M" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B38M" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B39M" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B3XM" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B701" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B703" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B712" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B720" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B721" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B722" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B732" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B733" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B734" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B735" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B736" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B737" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B738" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="B379" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="DC91" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="DC92" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="DC93" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="DC94" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="DC95" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="MD81" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="MD82" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="MD83" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="MD87" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="MD88" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="MD90" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="APJ" TypeCode="P3" ModelName="Airbus A320 Neo PEACH KanColle//Airbus A320 Neo PEACH" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="A318" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="A319" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="A320" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="A321" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="A19N" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="A21N" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B37M" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B38M" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B39M" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B3XM" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B701" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B703" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B712" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B720" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B721" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B722" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B732" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B733" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B734" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B735" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B736" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B737" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B738" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="B379" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="DC91" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="DC92" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="DC93" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="DC94" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="DC95" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="MD81" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="MD82" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="MD83" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="MD87" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="MD88" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="MD90" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KLM" TypeCode="P3" ModelName="Airbus A320 Neo KLM//Airbus A320 Neo KLM Pride" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="A318" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="A319" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="A320" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="A321" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="A19N" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="A21N" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B37M" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B38M" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B39M" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B3XM" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B701" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B703" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B712" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B720" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B721" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B722" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B732" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B733" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B734" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B735" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B736" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B737" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B738" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="B379" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="DC91" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="DC92" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="DC93" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="DC94" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="DC95" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="MD81" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="MD82" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="MD83" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="MD87" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="MD88" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="MD90" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="KAL" TypeCode="P3" ModelName="Airbus A320 Neo KoreanAir" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="A318" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="A319" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="A320" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="A321" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="A19N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="A21N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B37M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B38M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B39M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B3XM" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B701" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B703" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B712" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B720" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B721" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B722" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B732" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B733" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B734" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B735" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B736" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B737" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B738" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="B379" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="DC91" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="DC92" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="DC93" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="DC94" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="DC95" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="MD81" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="MD82" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="MD83" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="MD87" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="MD88" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="MD90" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAN" TypeCode="P3" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="A318" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="A319" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="A320" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="A321" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="A19N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="A21N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B37M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B38M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B39M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B3XM" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B701" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B703" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B712" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B720" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B721" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B722" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B732" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B733" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B734" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B735" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B736" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B737" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B738" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="B379" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="DC91" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="DC92" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="DC93" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="DC94" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="DC95" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="MD81" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="MD82" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="MD83" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="MD87" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="MD88" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="MD90" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LPE" TypeCode="P3" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="A318" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="A319" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="A320" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="A321" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="A19N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="A21N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B37M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B38M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B39M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B3XM" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B701" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B703" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B712" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B720" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B721" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B722" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B732" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B733" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B734" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B735" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B736" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B737" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B738" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="B379" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="DC91" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="DC92" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="DC93" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="DC94" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="DC95" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="MD81" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="MD82" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="MD83" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="MD87" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="MD88" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="MD90" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LXP" TypeCode="P3" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="A318" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="A319" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="A320" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="A321" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="A19N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="A21N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B37M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B38M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B39M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B3XM" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B701" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B703" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B712" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B720" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B721" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B722" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B732" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B733" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B734" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B735" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B736" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B737" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B738" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="B379" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="DC91" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="DC92" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="DC93" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="DC94" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="DC95" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="MD81" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="MD82" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="MD83" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="MD87" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="MD88" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="MD90" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LAP" TypeCode="P3" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="A318" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="A319" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="A320" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="A321" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="A19N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="A21N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B37M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B38M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B39M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B3XM" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B701" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B703" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B712" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B720" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B721" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B722" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B732" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B733" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B734" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B735" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B736" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B737" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B738" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="B379" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="DC91" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="DC92" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="DC93" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="DC94" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="DC95" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="MD81" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="MD82" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="MD83" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="MD87" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="MD88" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="MD90" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="ARE" TypeCode="P3" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="A318" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="A319" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="A320" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="A321" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="A19N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="A21N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B37M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B38M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B39M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B3XM" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B701" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B703" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B712" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B720" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B721" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B722" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B732" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B733" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B734" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B735" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B736" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B737" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B738" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="B379" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="DC91" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="DC92" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="DC93" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="DC94" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="DC95" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="MD81" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="MD82" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="MD83" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="MD87" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="MD88" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="MD90" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LCO" TypeCode="P3" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="A318" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="A319" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="A320" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="A321" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="A19N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="A21N" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B37M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B38M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B39M" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B3XM" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B701" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B703" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B712" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B720" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B721" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B722" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B732" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B733" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B734" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B735" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B736" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B737" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B738" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="B379" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="DC91" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="DC92" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="DC93" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="DC94" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="DC95" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="MD81" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="MD82" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="MD83" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="MD87" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="MD88" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="MD90" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="DSM" TypeCode="P3" ModelName="Airbus A320 Neo LATAM" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="A318" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="A319" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="A320" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="A321" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="A19N" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="A21N" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B37M" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B38M" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B39M" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B3XM" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B701" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B703" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B712" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B720" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B721" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B722" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B732" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B733" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B734" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B735" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B736" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B737" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B738" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="B379" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="DC91" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="DC92" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="DC93" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="DC94" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="DC95" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="MD81" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="MD82" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="MD83" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="MD87" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="MD88" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="MD90" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="LOT" TypeCode="P3" ModelName="Airbus A320 Neo PLL LOT" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="A318" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="A319" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="A320" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="A321" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="A19N" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="A21N" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B37M" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B38M" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B39M" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B3XM" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B701" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B703" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B712" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B720" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B721" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B722" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B732" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B733" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B734" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B735" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B736" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B737" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B738" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="B379" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="DC91" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="DC92" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="DC93" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="DC94" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="DC95" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="MD81" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="MD82" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="MD83" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="MD87" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="MD88" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="MD90" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="DLH" TypeCode="P3" ModelName="Airbus A320 Neo Lufthansa" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="A318" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="A319" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="A320" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="A321" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="A19N" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="A21N" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B37M" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B38M" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B39M" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B3XM" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B701" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B703" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B712" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B720" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B721" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B722" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B732" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B733" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B734" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B735" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B736" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B737" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B738" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="B379" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="DC91" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="DC92" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="DC93" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="DC94" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="DC95" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="MD81" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="MD82" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="MD83" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="MD87" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="MD88" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="MD90" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MAH" TypeCode="P3" ModelName="Airbus A320 Neo Malév" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="A318" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="A319" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="A320" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="A321" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="A19N" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="A21N" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B37M" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B38M" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B39M" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B3XM" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B701" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B703" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B712" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B720" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B721" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B722" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B732" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B733" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B734" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B735" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B736" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B737" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B738" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="B379" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="DC91" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="DC92" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="DC93" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="DC94" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="DC95" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="MD81" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="MD82" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="MD83" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="MD87" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="MD88" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="MD90" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MPH" TypeCode="P3" ModelName="Airbus A320 Neo Martinair (New)" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="A318" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="A319" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="A320" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="A321" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="A19N" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="A21N" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B37M" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B38M" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B39M" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B3XM" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B701" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B703" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B712" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B720" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B721" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B722" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B732" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B733" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B734" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B735" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B736" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B737" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B738" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="B379" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="DC91" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="DC92" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="DC93" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="DC94" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="DC95" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="MD81" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="MD82" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="MD83" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="MD87" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="MD88" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="MD90" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MEA" TypeCode="P3" ModelName="Airbus A320 Neo Middle East Airline" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="A318" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="A319" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="A320" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="A321" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="A19N" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="A21N" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B37M" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B38M" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B39M" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B3XM" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B701" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B703" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B712" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B720" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B721" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B722" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B732" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B733" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B734" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B735" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B736" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B737" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B738" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="B379" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="DC91" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="DC92" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="DC93" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="DC94" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="DC95" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="MD81" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="MD82" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="MD83" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="MD87" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="MD88" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="MD90" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="MON" TypeCode="P3" ModelName="Airbus A320 Neo MONARCH" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="A318" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="A319" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="A320" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="A321" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="A19N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="A21N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B37M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B38M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B39M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B3XM" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B701" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B703" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B712" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B720" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B721" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B722" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B732" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B733" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B734" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B735" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B736" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B737" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B738" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="B379" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="DC91" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="DC92" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="DC93" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="DC94" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="DC95" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="MD81" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="MD82" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="MD83" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="MD87" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="MD88" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="MD90" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAX" TypeCode="P3" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="A318" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="A319" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="A320" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="A321" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="A19N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="A21N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B37M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B38M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B39M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B3XM" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B701" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B703" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B712" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B720" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B721" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B722" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B732" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B733" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B734" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B735" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B736" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B737" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B738" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="B379" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="DC91" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="DC92" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="DC93" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="DC94" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="DC95" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="MD81" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="MD82" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="MD83" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="MD87" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="MD88" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="MD90" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NRS" TypeCode="P3" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="A318" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="A319" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="A320" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="A321" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="A19N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="A21N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B37M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B38M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B39M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B3XM" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B701" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B703" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B712" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B720" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B721" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B722" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B732" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B733" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B734" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B735" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B736" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B737" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B738" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="B379" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="DC91" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="DC92" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="DC93" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="DC94" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="DC95" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="MD81" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="MD82" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="MD83" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="MD87" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="MD88" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="MD90" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAA" TypeCode="P3" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="A318" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="A319" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="A320" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="A321" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="A19N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="A21N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B37M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B38M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B39M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B3XM" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B701" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B703" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B712" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B720" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B721" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B722" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B732" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B733" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B734" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B735" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B736" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B737" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B738" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="B379" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="DC91" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="DC92" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="DC93" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="DC94" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="DC95" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="MD81" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="MD82" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="MD83" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="MD87" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="MD88" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="MD90" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="IBK" TypeCode="P3" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="A318" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="A319" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="A320" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="A321" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="A19N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="A21N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B37M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B38M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B39M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B3XM" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B701" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B703" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B712" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B720" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B721" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B722" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B732" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B733" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B734" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B735" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B736" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B737" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B738" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="B379" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="DC91" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="DC92" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="DC93" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="DC94" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="DC95" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="MD81" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="MD82" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="MD83" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="MD87" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="MD88" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="MD90" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NAN" TypeCode="P3" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="A318" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="A319" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="A320" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="A321" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="A19N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="A21N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B37M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B38M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B39M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B3XM" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B701" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B703" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B712" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B720" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B721" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B722" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B732" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B733" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B734" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B735" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B736" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B737" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B738" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="B379" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="DC91" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="DC92" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="DC93" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="DC94" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="DC95" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="MD81" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="MD82" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="MD83" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="MD87" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="MD88" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="MD90" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NSW" TypeCode="P3" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="A318" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="A319" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="A320" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="A321" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="A19N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="A21N" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B37M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B38M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B39M" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B3XM" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B701" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B703" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B712" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B720" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B721" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B722" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B732" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B733" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B734" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B735" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B736" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B737" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B738" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="B379" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="DC91" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="DC92" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="DC93" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="DC94" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="DC95" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="MD81" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="MD82" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="MD83" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="MD87" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="MD88" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="MD90" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="NLH" TypeCode="P3" ModelName="Airbus A320 Neo Norwegian Erik Bye" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="A318" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="A319" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="A320" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="A321" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="A19N" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="A21N" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B37M" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B38M" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B39M" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B3XM" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B701" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B703" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B712" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B720" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B721" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B722" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B732" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B733" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B734" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B735" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B736" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B737" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B738" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="B379" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="DC91" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="DC92" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="DC93" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="DC94" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="DC95" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="MD81" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="MD82" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="MD83" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="MD87" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="MD88" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="MD90" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="ORX" TypeCode="P3" ModelName="Airbus A320 Neo Orbit Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="A318" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="A319" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="A320" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="A321" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="A19N" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="A21N" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B37M" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B38M" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B39M" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B3XM" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B701" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B703" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B712" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B720" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B721" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B722" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B732" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B733" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B734" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B735" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B736" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B737" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B738" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="B379" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="DC91" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="DC92" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="DC93" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="DC94" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="DC95" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="MD81" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="MD82" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="MD83" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="MD87" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="MD88" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="MD90" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PAL" TypeCode="P3" ModelName="Airbus A320 Neo Philippine Airlines" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="A318" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="A319" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="A320" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="A321" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="A19N" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="A21N" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B37M" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B38M" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B39M" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B3XM" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B701" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B703" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B712" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B720" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B721" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B722" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B732" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B733" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B734" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B735" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B736" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B737" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B738" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="B379" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="DC91" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="DC92" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="DC93" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="DC94" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="DC95" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="MD81" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="MD82" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="MD83" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="MD87" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="MD88" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="MD90" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PGT" TypeCode="P3" ModelName="Airbus A320 Neo Pegasus" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="A318" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="A319" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="A320" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="A321" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="A19N" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="A21N" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B37M" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B38M" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B39M" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B3XM" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B701" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B703" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B712" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B720" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B721" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B722" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B732" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B733" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B734" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B735" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B736" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B737" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B738" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="B379" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="DC91" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="DC92" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="DC93" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="DC94" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="DC95" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="MD81" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="MD82" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="MD83" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="MD87" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="MD88" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="MD90" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PIA" TypeCode="P3" ModelName="Airbus A320 Neo Pia" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="A318" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="A319" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="A320" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="A321" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="A19N" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="A21N" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B37M" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B38M" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B39M" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B3XM" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B701" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B703" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B712" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B720" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B721" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B722" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B732" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B733" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B734" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B735" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B736" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B737" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B738" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="B379" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="DC91" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="DC92" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="DC93" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="DC94" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="DC95" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="MD81" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="MD82" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="MD83" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="MD87" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="MD88" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="MD90" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="PRM" TypeCode="P3" ModelName="Airbus A320 Neo PRIME AIR" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="A318" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="A319" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="A320" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="A321" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="A19N" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="A21N" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B37M" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B38M" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B39M" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B3XM" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B701" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B703" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B712" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B720" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B721" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B722" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B732" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B733" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B734" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B735" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B736" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B737" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B738" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="B379" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="DC91" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="DC92" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="DC93" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="DC94" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="DC95" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="MD81" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="MD82" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="MD83" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="MD87" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="MD88" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="MD90" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="WAB" TypeCode="P3" ModelName="Airbus A320 Neo Play" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="A318" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="A319" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="A320" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="A321" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="A19N" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="A21N" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B37M" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B38M" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B39M" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B3XM" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B701" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B703" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B712" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B720" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B721" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B722" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B732" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B733" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B734" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B735" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B736" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B737" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B738" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="B379" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="DC91" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="DC92" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="DC93" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="DC94" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="DC95" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="MD81" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="MD82" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="MD83" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="MD87" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="MD88" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="MD90" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="POE" TypeCode="P3" ModelName="Airbus A320 Neo Porter" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="A318" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="A319" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="A320" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="A321" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="A19N" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="A21N" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B37M" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B38M" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B39M" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B3XM" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B701" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B703" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B712" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B720" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B721" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B722" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B732" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B733" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B734" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B735" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B736" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B737" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B738" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="B379" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="DC91" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="DC92" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="DC93" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="DC94" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="DC95" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="MD81" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="MD82" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="MD83" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="MD87" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="MD88" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="MD90" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QJE" TypeCode="P3" ModelName="Airbus A320 Neo QuantasLink" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="A318" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="A319" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="A320" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="A321" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="A19N" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="A21N" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B37M" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B38M" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B39M" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B3XM" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B701" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B703" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B712" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B720" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B721" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B722" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B732" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B733" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B734" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B735" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B736" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B737" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B738" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="B379" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="DC91" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="DC92" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="DC93" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="DC94" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="DC95" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="MD81" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="MD82" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="MD83" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="MD87" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="MD88" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="MD90" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="QTR" TypeCode="P3" ModelName="Airbus A320 Neo Qatar Airways" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="A318" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="A319" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="A320" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="A321" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="A19N" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="A21N" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B37M" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B38M" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B39M" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B701" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B703" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B712" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B720" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B721" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B722" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B732" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B733" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B734" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B735" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B736" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B737" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B738" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="B379" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="DC91" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="DC92" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="DC93" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="DC94" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="DC95" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="MD81" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="MD82" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="MD83" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="MD87" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="MD88" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="MD90" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="RAM" TypeCode="P3" ModelName="Airbus A320 Neo Air Royal Maroc AI" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="A318" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="A319" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="A320" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="A321" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="A19N" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="A21N" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B37M" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B38M" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B39M" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B701" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B703" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B712" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B720" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B721" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B722" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B732" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B733" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B734" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B735" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B736" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B737" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B738" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="B379" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="DC91" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="DC92" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="DC93" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="DC94" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="DC95" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="MD81" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="MD82" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="MD83" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="MD87" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="MD88" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="MD90" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="AMC" TypeCode="P3" ModelName="Airbus A320 Neo Air Malta" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="A318" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="A319" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="A320" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="A321" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="A19N" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="A21N" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B37M" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B38M" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B39M" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B3XM" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B701" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B703" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B712" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B720" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B721" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B722" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B732" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B733" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B734" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B735" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B736" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B737" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B738" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="B379" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="DC91" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="DC92" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="DC93" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="DC94" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="DC95" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="MD81" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="MD82" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="MD83" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="MD87" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="MD88" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="MD90" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="RYR" TypeCode="P3" ModelName="Airbus A320 Neo Ryanair//Airbus A320 Neo Ryanair Vodafone" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="A318" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="A319" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="A320" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="A321" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="A19N" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="A21N" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B37M" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B38M" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B39M" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B3XM" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B701" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B703" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B712" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B720" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B721" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B722" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B732" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B733" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B734" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B735" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B736" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B737" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B738" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="B379" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="DC91" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="DC92" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="DC93" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="DC94" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="DC95" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="MD81" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="MD82" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="MD83" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="MD87" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="MD88" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="MD90" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="OMS" TypeCode="P3" ModelName="Airbus A320 Neo SalamAir" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="A318" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="A319" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="A320" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="A321" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="A19N" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="A21N" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B37M" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B38M" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B39M" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B3XM" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B701" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B703" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B712" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B720" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B721" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B722" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B732" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B733" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B734" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B735" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B736" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B737" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B738" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="B379" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="DC91" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="DC92" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="DC93" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="DC94" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="DC95" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="MD81" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="MD82" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="MD83" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="MD87" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="MD88" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="MD90" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SVA" TypeCode="P3" ModelName="Airbus A320 Neo Saudia" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="A318" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="A319" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="A320" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="A321" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="A19N" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="A21N" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B37M" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B38M" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B39M" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B3XM" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B701" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B703" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B712" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B720" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B721" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B722" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B732" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B733" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B734" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B735" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B736" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B737" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B738" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="B379" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="DC91" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="DC92" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="DC93" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="DC94" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="DC95" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="MD81" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="MD82" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="MD83" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="MD87" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="MD88" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="MD90" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAS" TypeCode="P3" ModelName="Airbus A320 Neo SAS" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="A318" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="A319" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="A320" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="A321" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="A19N" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="A21N" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B37M" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B38M" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B39M" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B3XM" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B701" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B703" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B712" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B720" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B721" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B722" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B732" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B733" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B734" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B735" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B736" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B737" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B738" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="B379" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="DC91" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="DC92" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="DC93" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="DC94" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="DC95" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="MD81" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="MD82" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="MD83" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="MD87" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="MD88" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="MD90" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SAT" TypeCode="P3" ModelName="Airbus A320 Neo SATA" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="A318" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="A319" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="A320" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="A321" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="A19N" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="A21N" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B37M" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B38M" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B39M" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B3XM" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B701" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B703" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B712" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B720" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B721" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B722" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B732" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B733" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B734" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B735" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B736" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B737" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B738" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="B379" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="DC91" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="DC92" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="DC93" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="DC94" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="DC95" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="MD81" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="MD82" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="MD83" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="MD87" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="MD88" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="MD90" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="SBI" TypeCode="P3" ModelName="Airbus A320 Neo S7 Airlines" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A318" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A319" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A320" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A321" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A19N" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A21N" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B37M" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B38M" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B39M" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B3XM" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B701" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B703" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B712" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B720" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B721" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B722" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B732" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B733" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B734" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B735" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B736" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B737" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B738" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B379" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC91" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC92" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC93" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC94" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC95" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD81" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD82" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD83" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD87" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD88" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD90" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="P3" ModelName="Airbus A320 Neo Scoot" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="A318" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="A319" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="A320" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="A321" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="A19N" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="A21N" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B37M" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B38M" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B39M" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B3XM" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B701" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B703" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B712" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B720" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B721" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B722" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B732" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B733" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B734" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B735" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B736" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B737" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B738" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="B379" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="DC91" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="DC92" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="DC93" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="DC94" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="DC95" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="MD81" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="MD82" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="MD83" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="MD87" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="MD88" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="MD90" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SEJ" TypeCode="P3" ModelName="Airbus A320 Neo SpiceJet" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="A318" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="A319" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="A320" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="A321" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="A19N" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="A21N" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B37M" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B38M" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B39M" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B3XM" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B701" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B703" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B712" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B720" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B721" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B722" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B732" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B733" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B734" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B735" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B736" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B737" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B738" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="B379" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="DC91" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="DC92" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="DC93" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="DC94" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="DC95" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="MD81" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="MD82" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="MD83" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="MD87" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="MD88" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="MD90" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SIA" TypeCode="P3" ModelName="Airbus A320 Neo SQ" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="A318" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="A319" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="A320" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="A321" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="A19N" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="A21N" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B37M" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B38M" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B39M" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B3XM" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B701" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B703" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B712" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B720" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B721" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B722" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B732" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B733" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B734" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B735" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B736" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B737" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B738" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="B379" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="DC91" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="DC92" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="DC93" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="DC94" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="DC95" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="MD81" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="MD82" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="MD83" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="MD87" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="MD88" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="MD90" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SJX" TypeCode="P3" ModelName="Airbus A320 Neo StarLux Airlines" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="A318" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="A319" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="A320" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="A321" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="A19N" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="A21N" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B37M" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B38M" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B39M" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B3XM" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B701" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B703" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B712" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B720" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B721" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B722" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B732" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B733" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B734" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B735" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B736" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B737" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B738" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="B379" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="DC91" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="DC92" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="DC93" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="DC94" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="DC95" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="MD81" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="MD82" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="MD83" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="MD87" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="MD88" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="MD90" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SKU" TypeCode="P3" ModelName="Airbus A320 Neo Sky Airline" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="A318" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="A319" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="A320" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="A321" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="A19N" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="A21N" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B37M" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B38M" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B39M" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B3XM" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B701" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B703" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B712" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B720" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B721" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B722" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B732" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B733" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B734" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B735" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B736" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B737" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B738" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="B379" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="DC91" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="DC92" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="DC93" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="DC94" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="DC95" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="MD81" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="MD82" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="MD83" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="MD87" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="MD88" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="MD90" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="SWA" TypeCode="P3" ModelName="Airbus A320 Neo Southwest Airlines" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="A318" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="A319" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="A320" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="A321" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="A19N" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="A21N" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B37M" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B38M" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B39M" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B3XM" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B701" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B703" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B712" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B720" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B721" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B722" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B732" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B733" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B734" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B735" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B736" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B737" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B738" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="B379" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="DC91" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="DC92" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="DC93" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="DC94" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="DC95" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="MD81" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="MD82" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="MD83" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="MD87" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="MD88" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="MD90" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="ANZ" TypeCode="P3" ModelName="Airbus A320 Neo Air New Zealand Black Livery//Airbus A320 Neo Air New Zealand White Livery" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="A318" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="A319" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="A320" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="A321" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="A19N" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="A21N" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B37M" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B38M" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B39M" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B3XM" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B701" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B703" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B712" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B720" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B721" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B722" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B732" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B733" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B734" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B735" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B736" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B737" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B738" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="B379" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="DC91" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="DC92" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="DC93" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="DC94" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="DC95" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="MD81" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="MD82" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="MD83" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="MD87" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="MD88" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="MD90" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="SWR" TypeCode="P3" ModelName="Airbus A320 Neo Swiss Air" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="A318" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="A319" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="A320" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="A321" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="A19N" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="A21N" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B37M" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B38M" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B39M" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B3XM" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B701" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B703" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B712" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B720" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B721" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B722" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B732" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B733" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B734" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B735" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B736" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B737" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B738" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="B379" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="DC91" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="DC92" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="DC93" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="DC94" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="DC95" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="MD81" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="MD82" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="MD83" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="MD87" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="MD88" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="MD90" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAM" TypeCode="P3" ModelName="Airbus A320 Neo TAM" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="A318" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="A319" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="A320" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="A321" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="A19N" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="A21N" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B37M" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B38M" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B39M" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B3XM" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B701" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B703" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B712" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B720" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B721" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B722" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B732" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B733" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B734" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B735" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B736" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B737" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B738" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="B379" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="DC91" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="DC92" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="DC93" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="DC94" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="DC95" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="MD81" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="MD82" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="MD83" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="MD87" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="MD88" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="MD90" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TAP" TypeCode="P3" ModelName="Airbus A320 Neo TAP PORTUGAL  AI" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A318" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A319" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A320" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A321" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A19N" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="A21N" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B37M" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B38M" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B39M" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B3XM" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B701" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B703" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B712" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B720" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B721" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B722" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B732" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B733" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B734" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B735" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B736" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B737" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B738" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="B379" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC91" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC92" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC93" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC94" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="DC95" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD81" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD82" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD83" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD87" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD88" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="MD90" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGW" TypeCode="P3" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="A318" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="A319" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="A320" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="A321" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="A19N" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="A21N" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B37M" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B38M" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B39M" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B3XM" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B701" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B703" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B712" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B720" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B721" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B722" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B732" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B733" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B734" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B735" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B736" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B737" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B738" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="B379" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="DC91" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="DC92" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="DC93" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="DC94" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="DC95" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="MD81" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="MD82" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="MD83" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="MD87" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="MD88" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="MD90" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TGG" TypeCode="P3" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="A318" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="A319" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="A320" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="A321" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="A19N" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="A21N" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B37M" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B38M" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B39M" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B3XM" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B701" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B703" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B712" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B720" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B721" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B722" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B732" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B733" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B734" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B735" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B736" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B737" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B738" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="B379" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="DC91" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="DC92" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="DC93" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="DC94" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="DC95" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="MD81" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="MD82" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="MD83" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="MD87" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="MD88" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="MD90" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="MDL" TypeCode="P3" ModelName="Airbus A320 Neo Tiger" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="A318" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="A319" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="A320" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="A321" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="A19N" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="A21N" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B37M" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B38M" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B39M" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B3XM" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B701" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B703" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B712" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B720" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B721" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B722" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B732" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B733" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B734" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B735" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B736" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B737" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B738" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="B379" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="DC91" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="DC92" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="DC93" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="DC94" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="DC95" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="MD81" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="MD82" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="MD83" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="MD87" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="MD88" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="MD90" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="TTW" TypeCode="P3" ModelName="Airbus A320 Neo Tigerair Taiwan SoccerYCA" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="A318" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="A319" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="A320" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="A321" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="A19N" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="A21N" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B37M" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B38M" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B39M" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B3XM" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B701" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B703" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B712" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B720" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B721" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B722" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B732" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B733" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B734" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B735" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B736" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B737" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B738" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="B379" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="DC91" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="DC92" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="DC93" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="DC94" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="DC95" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="MD81" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="MD82" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="MD83" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="MD87" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="MD88" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="MD90" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="AWC" TypeCode="P3" ModelName="Airbus A320 Neo Titan Airways  AI" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A318" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A319" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A320" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A321" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A19N" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="A21N" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B37M" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B38M" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B39M" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B3XM" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B701" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B703" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B712" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B720" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B721" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B722" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B732" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B733" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B734" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B735" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B736" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B737" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B738" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="B379" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC91" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC92" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC93" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC94" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="DC95" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD81" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD82" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD83" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD87" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD88" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="MD90" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="ARG" TypeCode="P3" ModelName="Airbus A320 Neo Areolineas Argentinas" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="A318" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="A319" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="A320" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="A321" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="A19N" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="A21N" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B37M" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B38M" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B39M" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B3XM" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B701" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B703" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B712" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B720" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B721" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B722" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B732" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B733" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B734" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B735" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B736" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B737" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B738" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="B379" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="DC91" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="DC92" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="DC93" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="DC94" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="DC95" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="MD81" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="MD82" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="MD83" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="MD87" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="MD88" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="MD90" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="AUR" TypeCode="P3" ModelName="Airbus A320 Neo Aurigny" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="A318" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="A319" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="A320" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="A321" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="A19N" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="A21N" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B37M" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B38M" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B39M" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B701" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B703" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B712" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B720" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B721" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B722" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B732" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B733" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B734" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B735" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B736" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B737" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B738" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="B379" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="DC91" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="DC92" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="DC93" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="DC94" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="DC95" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="MD81" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="MD82" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="MD83" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="MD87" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="MD88" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="MD90" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="BER" TypeCode="P3" ModelName="Airbus A320 Neo Air Berlin" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="A318" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="A319" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="A320" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="A321" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="A19N" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="A21N" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B37M" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B38M" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B39M" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B701" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B703" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B712" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B720" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B721" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B722" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B732" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B733" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B734" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B735" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B736" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B737" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B738" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="B379" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="DC91" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="DC92" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="DC93" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="DC94" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="DC95" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="MD81" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="MD82" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="MD83" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="MD87" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="MD88" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="MD90" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="ABL" TypeCode="P3" ModelName="Airbus A320 Neo Air Busan" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="A318" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="A319" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="A320" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="A321" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="A19N" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="A21N" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B37M" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B38M" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B39M" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B3XM" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B701" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B703" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B712" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B720" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B721" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B722" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B732" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B733" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B734" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B735" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B736" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B737" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B738" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="B379" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="DC91" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="DC92" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="DC93" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="DC94" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="DC95" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="MD81" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="MD82" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="MD83" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="MD87" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="MD88" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="MD90" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="BTN" TypeCode="P3" ModelName="Airbus A320 Neo Bhutan Air" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="A318" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="A319" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="A320" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="A321" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="A19N" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="A21N" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B37M" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B38M" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B39M" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B3XM" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B701" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B703" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B712" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B720" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B721" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B722" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B732" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B733" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B734" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B735" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B736" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B737" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B738" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="B379" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="DC91" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="DC92" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="DC93" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="DC94" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="DC95" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="MD81" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="MD82" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="MD83" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="MD87" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="MD88" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="MD90" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="CIB" TypeCode="P3" ModelName="Airbus A320 Neo Condor" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="A318" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="A319" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="A320" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="A321" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="A19N" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="A21N" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B37M" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B38M" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B39M" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B701" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B703" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B712" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B720" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B721" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B722" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B732" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B733" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B734" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B735" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B736" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B737" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B738" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="B379" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="DC91" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="DC92" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="DC93" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="DC94" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="DC95" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="MD81" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="MD82" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="MD83" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="MD87" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="MD88" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="MD90" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="DLA" TypeCode="P3" ModelName="Airbus A320 Neo Air Dolomiti" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="A318" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="A319" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="A320" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="A321" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="A19N" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="A21N" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B37M" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B38M" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B39M" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B701" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B703" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B712" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B720" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B721" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B722" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B732" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B733" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B734" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B735" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B736" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B737" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B738" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="B379" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="DC91" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="DC92" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="DC93" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="DC94" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="DC95" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="MD81" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="MD82" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="MD83" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="MD87" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="MD88" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="MD90" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="AKL" TypeCode="P3" ModelName="Airbus A320 Neo Air Kiribati" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="A318" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="A319" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="A320" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="A321" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="A19N" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="A21N" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B37M" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B38M" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B39M" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B3XM" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B701" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B703" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B712" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B720" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B721" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B722" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B732" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B733" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B734" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B735" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B736" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B737" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B738" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="B379" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="DC91" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="DC92" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="DC93" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="DC94" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="DC95" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="MD81" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="MD82" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="MD83" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="MD87" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="MD88" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="MD90" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="PAA" TypeCode="P3" ModelName="Airbus A320 Neo Pan Am" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="A318" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="A319" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="A320" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="A321" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="A19N" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="A21N" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B37M" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B38M" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B39M" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B3XM" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B701" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B703" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B712" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B720" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B721" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B722" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B732" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B733" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B734" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B735" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B736" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B737" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B738" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="B379" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="DC91" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="DC92" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="DC93" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="DC94" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="DC95" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="MD81" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="MD82" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="MD83" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="MD87" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="MD88" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="MD90" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="NKS" TypeCode="P3" ModelName="Airbus A320 Neo Spirit 2" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="A318" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="A319" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="A320" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="A321" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="A19N" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="A21N" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B37M" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B38M" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B39M" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B3XM" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B701" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B703" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B712" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B720" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B721" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B722" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B732" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B733" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B734" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B735" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B736" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B737" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B738" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="B379" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="DC91" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="DC92" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="DC93" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="DC94" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="DC95" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="MD81" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="MD82" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="MD83" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="MD87" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="MD88" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="MD90" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="THD" TypeCode="P3" ModelName="Airbus A320 Neo Thai" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="A318" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="A319" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="A320" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="A321" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="A19N" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="A21N" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B37M" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B38M" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B39M" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B701" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B703" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B712" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B720" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B721" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B722" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B732" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B733" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B734" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B735" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B736" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B737" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B738" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="B379" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="DC91" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="DC92" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="DC93" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="DC94" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="DC95" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="MD81" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="MD82" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="MD83" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="MD87" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="MD88" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="MD90" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TSC" TypeCode="P3" ModelName="Airbus A320 Neo Air Transat" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="A318" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="A319" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="A320" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="A321" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="A19N" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="A21N" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B37M" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B38M" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B39M" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B3XM" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B701" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B703" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B712" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B720" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B721" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B722" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B732" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B733" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B734" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B735" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B736" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B737" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B738" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="B379" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="DC91" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="DC92" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="DC93" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="DC94" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="DC95" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="MD81" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="MD82" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="MD83" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="MD87" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="MD88" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="MD90" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="TVF" TypeCode="P3" ModelName="Airbus A320 Neo Air Transavia" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="A318" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="A319" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="A320" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="A321" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="A19N" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="A21N" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B37M" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B38M" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B39M" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B3XM" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B701" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B703" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B712" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B720" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B721" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B722" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B732" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B733" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B734" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B735" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B736" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B737" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B738" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="B379" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="DC91" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="DC92" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="DC93" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="DC94" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="DC95" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="MD81" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="MD82" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="MD83" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="MD87" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="MD88" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="MD90" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="SWG" TypeCode="P3" ModelName="Airbus A320 Neo Sunwing TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="A318" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="A319" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="A320" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="A321" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="A19N" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="A21N" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B37M" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B38M" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B39M" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B3XM" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B701" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B703" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B712" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B720" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B721" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B722" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B732" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B733" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B734" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B735" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B736" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B737" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B738" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="B379" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="DC91" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="DC92" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="DC93" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="DC94" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="DC95" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="MD81" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="MD82" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="MD83" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="MD87" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="MD88" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="MD90" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLX" TypeCode="P3" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="A318" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="A319" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="A320" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="A321" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="A19N" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="A21N" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B37M" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B38M" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B39M" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B3XM" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B701" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B703" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B712" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B720" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B721" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B722" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B732" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B733" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B734" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B735" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B736" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B737" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B738" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="B379" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="DC91" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="DC92" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="DC93" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="DC94" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="DC95" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="MD81" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="MD82" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="MD83" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="MD87" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="MD88" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="MD90" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="HLF" TypeCode="P3" ModelName="Airbus A320 Neo TUI Blue//Airbus A320 Neo TUI" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="A318" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="A319" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="A320" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="A321" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="A19N" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="A21N" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B37M" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B38M" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B39M" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B3XM" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B701" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B703" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B712" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B720" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B721" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B722" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B732" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B733" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B734" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B735" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B736" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B737" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B738" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="B379" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="DC91" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="DC92" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="DC93" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="DC94" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="DC95" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="MD81" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="MD82" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="MD83" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="MD87" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="MD88" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="MD90" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TUI" TypeCode="P3" ModelName="Airbus A320 Neo Tunisair" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="A318" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="A319" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="A320" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="A321" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="A19N" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="A21N" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B37M" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B38M" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B39M" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B3XM" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B701" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B703" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B712" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B720" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B721" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B722" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B732" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B733" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B734" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B735" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B736" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B737" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B738" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="B379" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="DC91" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="DC92" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="DC93" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="DC94" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="DC95" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="MD81" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="MD82" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="MD83" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="MD87" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="MD88" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="MD90" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="TFX" TypeCode="P3" ModelName="Airbus A320 Neo Toll Cargo" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A318" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A319" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A320" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A321" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A19N" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="A21N" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B37M" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B38M" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B39M" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B3XM" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B701" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B703" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B712" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B720" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B721" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B722" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B732" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B733" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B734" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B735" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B736" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B737" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B738" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="B379" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC91" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC92" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC93" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC94" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="DC95" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD81" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD82" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD83" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD87" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD88" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="MD90" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="THY" TypeCode="P3" ModelName="Airbus A320 Neo Turkish" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="A318" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="A319" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="A320" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="A321" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="A19N" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="A21N" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B37M" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B38M" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B39M" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B3XM" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B701" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B703" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B712" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B720" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B721" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B722" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B732" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B733" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B734" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B735" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B736" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B737" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B738" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="B379" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="DC91" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="DC92" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="DC93" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="DC94" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="DC95" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="MD81" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="MD82" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="MD83" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="MD87" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="MD88" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="MD90" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="UPS" TypeCode="P3" ModelName="Airbus A320 Neo UPS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="A318" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="A319" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="A320" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="A321" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="A19N" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="A21N" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B37M" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B38M" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B39M" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B3XM" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B701" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B703" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B712" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B720" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B721" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B722" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B732" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B733" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B734" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B735" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B736" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B737" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B738" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="B379" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="DC91" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="DC92" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="DC93" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="DC94" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="DC95" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="MD81" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="MD82" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="MD83" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="MD87" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="MD88" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="MD90" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="AWE" TypeCode="P3" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="A318" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="A319" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="A320" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="A321" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="A19N" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="A21N" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B37M" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B38M" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B39M" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B3XM" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B701" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B703" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B712" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B720" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B721" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B722" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B732" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B733" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B734" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B735" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B736" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B737" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B738" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="B379" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="DC91" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="DC92" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="DC93" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="DC94" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="DC95" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="MD81" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="MD82" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="MD83" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="MD87" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="MD88" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="MD90" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="USA" TypeCode="P3" ModelName="Airbus A320 Neo US AIRWAYS" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="A318" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="A319" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="A320" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="A321" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="A19N" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="A21N" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B37M" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B38M" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B39M" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B3XM" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B701" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B703" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B712" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B720" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B721" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B722" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B732" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B733" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B734" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B735" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B736" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B737" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B738" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="B379" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="DC91" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="DC92" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="DC93" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="DC94" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="DC95" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="MD81" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="MD82" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="MD83" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="MD87" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="MD88" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="MD90" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="UAL" TypeCode="P3" ModelName="Airbus A320 Neo United//Airbus A320 Neo United (Merger)//Airbus A320 Neo United Gold" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="A318" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="A319" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="A320" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="A321" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="A19N" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="A21N" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B37M" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B38M" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B39M" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B3XM" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B701" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B703" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B712" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B720" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B721" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B722" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B732" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B733" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B734" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B735" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B736" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B737" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B738" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="B379" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="DC91" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="DC92" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="DC93" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="DC94" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="DC95" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="MD81" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="MD82" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="MD83" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="MD87" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="MD88" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="MD90" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="AF" TypeCode="P3" ModelName="Airbus A320 Neo United States Air Force" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="A318" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="A319" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="A320" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="A321" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="A19N" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="A21N" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B37M" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B38M" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B39M" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B3XM" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B701" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B703" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B712" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B720" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B721" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B722" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B732" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B733" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B734" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B735" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B736" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B737" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B738" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="B379" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="DC91" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="DC92" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="DC93" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="DC94" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="DC95" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="MD81" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="MD82" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="MD83" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="MD87" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="MD88" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="MD90" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="HVN" TypeCode="P3" ModelName="Airbus A320 Neo Vietnam Airlines" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="A318" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="A319" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="A320" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="A321" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="A19N" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="A21N" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B37M" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B38M" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B39M" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B3XM" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B701" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B703" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B712" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B720" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B721" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B722" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B732" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B733" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B734" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B735" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B736" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B737" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B738" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="B379" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="DC91" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="DC92" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="DC93" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="DC94" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="DC95" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="MD81" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="MD82" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="MD83" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="MD87" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="MD88" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="MD90" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VRD" TypeCode="P3" ModelName="Airbus A320 Neo Virgin America" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="A318" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="A319" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="A320" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="A321" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="A19N" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="A21N" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B37M" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B38M" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B39M" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B3XM" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B701" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B703" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B712" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B720" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B721" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B722" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B732" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B733" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B734" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B735" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B736" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B737" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B738" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="B379" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="DC91" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="DC92" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="DC93" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="DC94" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="DC95" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="MD81" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="MD82" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="MD83" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="MD87" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="MD88" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="MD90" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VIR" TypeCode="P3" ModelName="Airbus A320 Neo Virgin Atlantic" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="A318" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="A319" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="A320" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="A321" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="A19N" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="A21N" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B37M" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B38M" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B39M" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B3XM" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B701" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B703" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B712" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B720" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B721" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B722" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B732" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B733" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B734" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B735" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B736" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B737" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B738" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="B379" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="DC91" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="DC92" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="DC93" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="DC94" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="DC95" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="MD81" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="MD82" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="MD83" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="MD87" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="MD88" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="MD90" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOZ" TypeCode="P3" ModelName="Airbus A320 Neo Virgin Australia//Airbus A320 Neo Virgin Blue" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="A318" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="A319" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="A320" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="A321" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="A19N" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="A21N" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B37M" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B38M" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B39M" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B3XM" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B701" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B703" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B712" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B720" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B721" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B722" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B732" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B733" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B734" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B735" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B736" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B737" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B738" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="B379" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="DC91" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="DC92" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="DC93" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="DC94" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="DC95" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="MD81" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="MD82" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="MD83" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="MD87" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="MD88" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="MD90" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="VOI" TypeCode="P3" ModelName="Airbus A320 Neo Volaris" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="A318" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="A319" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="A320" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="A321" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="A19N" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="A21N" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B37M" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B38M" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B39M" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B3XM" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B701" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B703" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B712" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B720" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B721" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B722" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B732" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B733" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B734" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B735" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B736" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B737" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B738" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="B379" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="DC91" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="DC92" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="DC93" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="DC94" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="DC95" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="MD81" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="MD82" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="MD83" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="MD87" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="MD88" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="MD90" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WJA" TypeCode="P3" ModelName="Airbus A320 Neo WestJet" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="A318" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="A319" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="A320" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="A321" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="A19N" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="A21N" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B37M" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B38M" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B39M" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B3XM" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B701" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B703" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B712" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B720" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B721" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B722" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B732" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B733" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B734" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B735" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B736" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B737" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B738" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="B379" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="DC91" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="DC92" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="DC93" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="DC94" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="DC95" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="MD81" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="MD82" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="MD83" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="MD87" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="MD88" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="MD90" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WIF" TypeCode="P3" ModelName="Airbus A320 Neo Wideroe" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="A318" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="A319" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="A320" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="A321" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="A19N" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="A21N" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B37M" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B38M" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B39M" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B3XM" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B701" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B703" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B712" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B720" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B721" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B722" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B732" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B733" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B734" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B735" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B736" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B737" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B738" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="B379" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="DC91" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="DC92" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="DC93" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="DC94" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="DC95" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="MD81" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="MD82" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="MD83" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="MD87" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="MD88" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="MD90" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WZZ" TypeCode="P3" ModelName="Airbus A320 Neo Wizz Air 2//Airbus A320 Neo Wizz Air" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="A318" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="A319" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="A320" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="A321" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="A19N" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="A21N" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B37M" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B38M" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B39M" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B3XM" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B701" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B703" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B712" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B720" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B721" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B722" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B732" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B733" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B734" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B735" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B736" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B737" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B738" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="B379" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="DC91" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="DC92" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="DC93" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="DC94" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="DC95" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="MD81" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="MD82" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="MD83" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="MD87" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="MD88" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="MD90" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="WVL" TypeCode="P3" ModelName="Airbus A320 Neo Wizz Air Budapest" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="A318" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="A319" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="A320" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="A321" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="A19N" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="A21N" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B37M" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B38M" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B39M" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B3XM" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B701" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B703" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B712" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B720" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B721" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B722" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B732" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B733" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B734" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B735" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B736" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B737" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B738" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="B379" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="DC91" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="DC92" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="DC93" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="DC94" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="DC95" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="MD81" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="MD82" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="MD83" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="MD87" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="MD88" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="MD90" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="UZB" TypeCode="P3" ModelName="Airbus A320 Neo Uzbekistan Airways UK32022" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="A318" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="A319" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="A320" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="A321" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="A19N" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="A21N" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B37M" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B38M" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B39M" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B3XM" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B701" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B703" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B712" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B720" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B721" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B722" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B732" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B733" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B734" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B735" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B736" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B737" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B738" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="B379" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="DC91" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="DC92" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="DC93" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="DC94" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="DC95" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="MD81" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="MD82" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="MD83" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="MD87" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="MD88" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="MD90" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule CallsignPrefix="VJC" TypeCode="P3" ModelName="Airbus A320 Neo Vietjet" />
+	<ModelMatchRule TypeCode="A318" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="A319" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="A320" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="A321" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="A19N" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="A21N" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B37M" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B38M" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B39M" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B3XM" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B701" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B703" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B712" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B720" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B721" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B722" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B732" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B733" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B734" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B735" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B736" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B737" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B738" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="B379" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="DC91" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="DC92" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="DC93" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="DC94" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="DC95" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="MD81" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="MD82" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="MD83" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="MD87" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="MD88" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="MD90" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
+	<ModelMatchRule TypeCode="P3" ModelName="Airbus A320 Neo Asobo//Airbus A320 Neo Around The Globe//Airbus A320 Neo Asobo AirTraffic 00//Airbus A320 Neo Asobo AirTraffic 01//Airbus A320 Neo Asobo AirTraffic 02" />
 </ModelMatchRuleSet>


### PR DESCRIPTION
I added all the alternate types from the default VATSIM rules for the A20X (like the Boeing 738 for example) therefore, now you can see most airliners with a livery on the A20X.